### PR TITLE
changed  initial value to null of primitive types

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -15,15 +15,7 @@ class Field {
       return this.options.default
     }
 
-    const type = this.type
-    if (type === Number) return null
-    if (type === String) return null
-    if (type === Date) return null
-    if (type === Boolean) return false
-    if (Array.isArray(type)) return []
-    if (type.prototype instanceof BaseEntity) return new type()
-
-    return undefined
+    return null
   }
 
   get validation() {

--- a/src/field.js
+++ b/src/field.js
@@ -1,5 +1,3 @@
-const { BaseEntity } = require("./baseEntity")
-
 class Field {
   constructor(type, options = {}) {
     this.name = ""

--- a/src/field.js
+++ b/src/field.js
@@ -13,7 +13,7 @@ class Field {
       return this.options.default
     }
 
-    return null
+    return undefined
   }
 
   get validation() {

--- a/src/field.js
+++ b/src/field.js
@@ -16,8 +16,8 @@ class Field {
     }
 
     const type = this.type
-    if (type === Number) return 0
-    if (type === String) return ""
+    if (type === Number) return null
+    if (type === String) return null
     if (type === Date) return null
     if (type === Boolean) return false
     if (Array.isArray(type)) return []

--- a/test/entity/serializationEntity.js
+++ b/test/entity/serializationEntity.js
@@ -227,13 +227,17 @@ describe('An entity', () => {
         it('valid data to JSON', () => {
             //given
             const AnEntity = givenAnEntityToBuildAJSON()
+            const AnTypeEntity = givenAnEntityToBeUsedAsType()
+
             const instance = new AnEntity()
             instance.field1 = 1
             instance.field2 = "1"
             instance.field3 = new Date('2019-09-30T23:45:34.324Z')
             instance.field4 = true
+            instance.field5 = new AnTypeEntity()
             instance.field5.f1 = true
             instance.field5.f2 = "2"
+            instance.field6 = []
             instance.field6.push({ f1: true, f2: "2" })
 
             //when
@@ -246,13 +250,16 @@ describe('An entity', () => {
         it('should allow extra fields from JSON', () => {
             //given
             const AnEntity = givenAnEntityToBuildAJSON()
+            const AnTypeEntity = givenAnEntityToBeUsedAsType()
             const instance = new AnEntity()
             instance.field1 = 1
             instance.field2 = "1"
             instance.field3 = new Date('2019-09-30T23:45:34.324Z')
             instance.field4 = true
+            instance.field5 = new AnTypeEntity()
             instance.field5.f1 = true
             instance.field5.f2 = "2"
+            instance.field6 = []
             instance.field6.push({ f1: true, f2: "2" })
             instance.field1x = 1
             instance.field2x = "1"
@@ -266,19 +273,22 @@ describe('An entity', () => {
             const json = JSON.stringify(instance.toJSON({ allowExtraKeys: true }))
 
             //then
-            assert.deepStrictEqual(json, '{"field1":1,"field2":"1","field3":"2019-09-30T23:45:34.324Z","field4":true,"field1x":1,"field2x":"1","field3x":"2019-09-30T23:45:34.324Z","field4x":true,"field5x":{"f1":true,"f2":"2"},"field6x":[{"f1":true,"f2":"2"}],"field5":{"f1":true,"f2":"2"},"field6":[{"f1":true,"f2":"2"}]}')
+            assert.deepStrictEqual(json, '{"field1":1,"field2":"1","field3":"2019-09-30T23:45:34.324Z","field4":true,"field5":{"f1":true,"f2":"2"},"field6":[{"f1":true,"f2":"2"}],"field1x":1,"field2x":"1","field3x":"2019-09-30T23:45:34.324Z","field4x":true,"field5x":{"f1":true,"f2":"2"},"field6x":[{"f1":true,"f2":"2"}]}')
         })
         
         it('invalid data to JSON', () => {
             //given
             const AnEntity = givenAnEntityToBuildAJSON()
+            const AnTypeEntity = givenAnEntityToBeUsedAsType()
             const instance = new AnEntity()
             instance.field1 = "1"
             instance.field2 = 1
             instance.field3 = 1
             instance.field4 = 1
+            instance.field5 = new AnTypeEntity()
             instance.field5.f1 = 2
             instance.field5.f2 = true
+            instance.field6 = []
             instance.field6.push({ f1: 2, f2: true })
             //when
             instance.validate()

--- a/test/field/entityType/entity.js
+++ b/test/field/entityType/entity.js
@@ -30,13 +30,13 @@ describe('A field', () => {
             return new AnEntity()
         }
 
-        it('should set a default value to a field', () => {
+        it('should set undefined as default value to a field', () => {
             //given
             const EntityType = givenAnEntityToBeUsedAsType()
             const instanceOfEntityType = new EntityType()
             const instance = givenAnEntityWithAEntityField()
             //then
-            assert.strictEqual(instance.field1, null)
+            assert.strictEqual(instance.field1, undefined)
             assert.deepStrictEqual(instanceOfEntityType.constructor.name, instance.meta.schema.field1.type.name)
         })
 

--- a/test/field/entityType/entity.js
+++ b/test/field/entityType/entity.js
@@ -36,8 +36,8 @@ describe('A field', () => {
             const instanceOfEntityType = new EntityType()
             const instance = givenAnEntityWithAEntityField()
             //then
-            assert(instance.field1 instanceof BaseEntity)
-            assert.deepStrictEqual(instance.field1.constructor.name, instanceOfEntityType.constructor.name)
+            assert.strictEqual(instance.field1, null)
+            assert.deepStrictEqual(instanceOfEntityType.constructor.name, instance.meta.schema.field1.type.name)
         })
 
         it('should set null as a default value to a field', () => {
@@ -91,7 +91,9 @@ describe('A field', () => {
 
         it('should validate type and have valid deep value', () => {
             //given
+            const EntityType = givenAnEntityToBeUsedAsType()
             const instance = givenAnEntityWithAEntityField()
+            instance.field1 = new EntityType()
             instance.field1.f1 = true
 
             //then
@@ -101,7 +103,9 @@ describe('A field', () => {
 
         it('should validate type and have invalid deep value', () => {
             //given
+            const EntityType = givenAnEntityToBeUsedAsType()
             const instance = givenAnEntityWithAEntityField()
+            instance.field1 = new EntityType()
             instance.field1.f1 = 1
 
             //then

--- a/test/field/entityType/entityArray.js
+++ b/test/field/entityType/entityArray.js
@@ -26,11 +26,11 @@ describe('A field', () => {
             return new AnEntity()
         }
 
-        it('should set a default value to a field', () => {
+        it('should set null as default value to a field', () => {
             //given
             const instance = givenAnEntityWithAEntityField()
             //then
-            assert.deepStrictEqual(instance.field1, [])
+            assert.deepStrictEqual(instance.field1, null)
         })
 
         it('should set null as a default value to a field', () => {
@@ -58,6 +58,7 @@ describe('A field', () => {
             //given
             const EntityType = givenAnEntityToBeUsedAsType()
             const instance = givenAnEntityWithAEntityField()
+            instance.field1 = []
             instance.field1[0] = new EntityType()
 
             //then
@@ -78,6 +79,7 @@ describe('A field', () => {
         it('should validate type and have valid deep value', () => {
             //given
             const instance = givenAnEntityWithAEntityField()
+            instance.field1 = []
             instance.field1[0] = EntityType.fromJSON({ f1: true, f2: false})
 
             //then
@@ -88,6 +90,7 @@ describe('A field', () => {
         it('should validate type and have invalid deep value', () => {
             //given
             const instance = givenAnEntityWithAEntityField()
+            instance.field1 = [0]
             instance.field1[0] = EntityType.fromJSON({ f1: "true", f2: "false"})
 
             //then

--- a/test/field/entityType/entityArray.js
+++ b/test/field/entityType/entityArray.js
@@ -26,11 +26,11 @@ describe('A field', () => {
             return new AnEntity()
         }
 
-        it('should set null as default value to a field', () => {
+        it('should set undefined as default value to a field', () => {
             //given
             const instance = givenAnEntityWithAEntityField()
             //then
-            assert.deepStrictEqual(instance.field1, null)
+            assert.deepStrictEqual(instance.field1, undefined)
         })
 
         it('should set null as a default value to a field', () => {

--- a/test/field/scalarTypes/boolean.js
+++ b/test/field/scalarTypes/boolean.js
@@ -13,11 +13,11 @@ describe('A field', () => {
             return new AnEntity()
         }
 
-        it('should set null as default value to a field', () => {
+        it('should set undefined as default value to a field', () => {
             //given
             const instance = givenAnEntityWithABooleanField()
             //then
-            assert.strictEqual(instance['field1'], null)
+            assert.strictEqual(instance['field1'], undefined)
         })
 
         it('should set a different default value to a field', () => {

--- a/test/field/scalarTypes/boolean.js
+++ b/test/field/scalarTypes/boolean.js
@@ -13,11 +13,11 @@ describe('A field', () => {
             return new AnEntity()
         }
 
-        it('should set a default value to a field', () => {
+        it('should set null as default value to a field', () => {
             //given
             const instance = givenAnEntityWithABooleanField()
             //then
-            assert.strictEqual(instance['field1'], false)
+            assert.strictEqual(instance['field1'], null)
         })
 
         it('should set a different default value to a field', () => {

--- a/test/field/scalarTypes/date.js
+++ b/test/field/scalarTypes/date.js
@@ -13,11 +13,11 @@ describe('A field', () => {
             return new AnEntity()
         }
 
-        it('should set null as default value to a field', () => {
+        it('should set undefined as default value to a field', () => {
             //given
             const instance = givenAnEntityWithADateField()
             //then
-            assert.strictEqual(instance['field1'], null)
+            assert.strictEqual(instance['field1'], undefined)
         })
 
         it('should set a different default value to a field', () => {

--- a/test/field/scalarTypes/date.js
+++ b/test/field/scalarTypes/date.js
@@ -13,7 +13,7 @@ describe('A field', () => {
             return new AnEntity()
         }
 
-        it('should set a default value to a field', () => {
+        it('should set null as default value to a field', () => {
             //given
             const instance = givenAnEntityWithADateField()
             //then

--- a/test/field/scalarTypes/number.js
+++ b/test/field/scalarTypes/number.js
@@ -13,7 +13,7 @@ describe('A field', () => {
             return new AnEntity()
         }
 
-        it('should set a default value to a field', () => {
+        it('should set null as default value to a field', () => {
             //given
             const instance = givenAnEntityWithANumberField()
             //then

--- a/test/field/scalarTypes/number.js
+++ b/test/field/scalarTypes/number.js
@@ -17,7 +17,7 @@ describe('A field', () => {
             //given
             const instance = givenAnEntityWithANumberField()
             //then
-            assert.strictEqual(instance['field1'], 0)
+            assert.strictEqual(instance['field1'], null)
         })
 
         it('should set a different default value to a field', () => {

--- a/test/field/scalarTypes/number.js
+++ b/test/field/scalarTypes/number.js
@@ -13,11 +13,11 @@ describe('A field', () => {
             return new AnEntity()
         }
 
-        it('should set null as default value to a field', () => {
+        it('should set undefined as default value to a field', () => {
             //given
             const instance = givenAnEntityWithANumberField()
             //then
-            assert.strictEqual(instance['field1'], null)
+            assert.strictEqual(instance['field1'], undefined)
         })
 
         it('should set a different default value to a field', () => {

--- a/test/field/scalarTypes/string.js
+++ b/test/field/scalarTypes/string.js
@@ -13,11 +13,11 @@ describe('A field', () => {
             return new AnEntity()
         }
 
-        it('should set null as default value to a field', () => {
+        it('should set undefined as default value to a field', () => {
             //given
             const instance = givenAnEntityWithAStringField()
             //then
-            assert.strictEqual(instance['field1'], null)
+            assert.strictEqual(instance['field1'], undefined)
         })
 
         it('should set a different default value to a field', () => {

--- a/test/field/scalarTypes/string.js
+++ b/test/field/scalarTypes/string.js
@@ -13,7 +13,7 @@ describe('A field', () => {
             return new AnEntity()
         }
 
-        it('should set a default value to a field', () => {
+        it('should set null as default value to a field', () => {
             //given
             const instance = givenAnEntityWithAStringField()
             //then

--- a/test/field/scalarTypes/string.js
+++ b/test/field/scalarTypes/string.js
@@ -17,7 +17,7 @@ describe('A field', () => {
             //given
             const instance = givenAnEntityWithAStringField()
             //then
-            assert.strictEqual(instance['field1'], "")
+            assert.strictEqual(instance['field1'], null)
         })
 
         it('should set a different default value to a field', () => {

--- a/test/field/validations.js
+++ b/test/field/validations.js
@@ -17,6 +17,8 @@ describe('A entity', () => {
         const examples =
             [
                 { type: Number, value: 1, validation: { numericality: { greaterThan: 10 } }, errors: { field1: [{ notGreaterThan: 10 }] } },
+                { type: String, value:  '', validation: { presence: true }, errors: { field1: [{ cantBeEmpty: true }] } },
+                { type: String, value:  null, validation: { presence: true }, errors: { field1: [{ cantBeEmpty: true }] } },
                 { type: String, value: "1", validation: { length: { minimum: 10 } }, errors: { field1: [{ isTooShort: 10 }] } },
                 { type: String, value: "http://##", validation: { url: true }, errors: { field1: [{ invalidURL: true }] } },
                 { type: String, value: "abc.example.com", validation: { email: true }, errors: { field1: [{ invalidEmail: true }] } },


### PR DESCRIPTION
Fixed errors in validation appointed on issue #28 

Before, number and string fields as initialized by `0` and `''`, so, when suma try's validate 0 as presence true they return true, since zero is different then null or undefined

I have changed de value initial value from string and `Number` to be null as default, from `String` in specific to keep the coherence, but the comportment keeps the same as before.