### PR TITLE
Adjust isValid to be a function in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ const user = new User()
 user.password = '1234'
 user.validate() 
 user.errors // { password: [ { isTooShort: 6 } ] }
-user.isValid // false
+user.isValid() // false
 ```
 
 ## Serialization


### PR DESCRIPTION
Fixes #

Fix example code where isValid was being used as a property instead of a function
