### PR TITLE
feat(base-entity): fields and ids getters on base entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,16 +259,6 @@ const User =
     })
 ```
 
-You can check if a field isId accessing the options of the field, like this:
-
-```javascript
-
-const user = new User()
-
-//should be equals ```true```
-user.__proto__.meta.schema.id.options.isId
-```
-
 ### Default value
 
 It is possible to define a default value when an entity instance is initiate.
@@ -364,6 +354,80 @@ Check if an object is a Gotu Entity class
 
         entity.isEntity(AnEntity) // true
         entity.isEntity(Object) // false
+```
+
+## Entity schema - `entity.schema`
+
+It is possible to access the schema information of your entity. There are two special properties:
+
+### fields
+
+Returns an list with all the fields of the entity:
+```javascript
+const User = entity('User', {
+    id: id(Number),
+    name: field(String, { validation: { presence: true }})
+})
+
+const fields = User.schema.fields
+
+// results in
+// [
+//   Field {
+//     name: 'id',
+//     type: [Function: Number],
+//     options: { isId: true },
+//     _validations: null
+//   },
+//   Field {
+//     name: 'name',
+//     type: [Function: String],
+//     options: { validation: [Object] },
+//     _validations: null
+//   }
+// ]
+```
+If the entity has no field, so it returns an emtpy array (`[]`)
+
+### ids
+
+Returns an list with all the ids of the entity:
+```javascript
+const User = entity('User', {
+    id: id(Number),
+    anotherId: field(String, { isId: true }),
+    name: field(String)
+})
+
+const ids = User.schema.ids
+
+// results in
+// [
+//   Field {
+//     name: 'id',
+//     type: [Function: Number],
+//     options: { isId: true },
+//     _validations: null
+//   },
+//   Field {
+//     name: 'anotherId',
+//     type: [Function: String],
+//     options: { isId: true },
+//     _validations: null
+//   }
+// ]
+```
+
+If the entity has no id, so it returns an emtpy array (`[]`)
+
+Another way to verify if a specific property is an id, is accessing the `isId` property in the field's options, like this:
+
+```javascript
+
+const user = new User()
+
+//should be equals ```true```
+user.__proto__.meta.schema.id.options.isId
 ```
 
 ## TODO

--- a/src/baseEntity.js
+++ b/src/baseEntity.js
@@ -1,5 +1,4 @@
-const { validate, checker } = require("@herbsjs/suma")
-const validateValue = validate
+const { validate: validateValue, checker } = require("@herbsjs/suma")
 
 class BaseEntity {
 
@@ -64,8 +63,8 @@ class BaseEntity {
     function deepCopy(obj, allowExtraKeys) {
       const copy = {}
 
-     const jsonKeys = allowExtraKeys ? Object.keys(obj) : []
-     const entityKeys = Object.keys(obj.meta.schema)
+      const jsonKeys = allowExtraKeys ? Object.keys(obj) : []
+      const entityKeys = Object.keys(obj.meta.schema)
 
       const mergedKeys = jsonKeys.concat(entityKeys.filter((item) => jsonKeys.indexOf(item) < 0))
 
@@ -123,6 +122,20 @@ class BaseEntity {
     }
 
     return instance
+  }
+
+  static get schema() {
+    const schema = this.prototype.meta.schema
+
+    return {
+      ...schema,
+      get fields() {
+        return Object.values(schema)
+      }, 
+      get ids() {
+        return Object.values(schema).filter(({ options }) => options.isId)
+      }
+    }
   }
 }
 

--- a/test/entity/fields.js
+++ b/test/entity/fields.js
@@ -1,0 +1,20 @@
+const { entity } = require('../../src/entity')
+const { field } = require('../../src/field')
+const { id } = require('../../src/customTypes/id')
+const assert = require('assert')
+
+describe('fields static getter', () => {
+    it('should return the fields metadata from the entity', () => {
+        const MyEntity = entity('MyEntity', {
+            first: id(String),
+            second: field(Number),
+        })
+
+        const fields = MyEntity.schema.fields
+
+        assert.deepEqual(fields, [
+            { ...id(String), name: 'first' },
+            { ...field(Number), name: 'second' }
+        ])
+    })
+})

--- a/test/entity/ids.js
+++ b/test/entity/ids.js
@@ -1,0 +1,21 @@
+const { entity } = require('../../src/entity')
+const { field } = require('../../src/field')
+const { id } = require('../../src/customTypes/id')
+const assert = require('assert')
+
+describe('ids static getter', () => {
+    it('should return the ids fields metadata from the entity', () => {
+        const MyEntity = entity('MyEntity', {
+            first: id(String),
+            second: field(Number, { isId: true }),
+            third: field(Number),
+        })
+
+        const fields = MyEntity.schema.ids
+
+        assert.deepEqual(fields, [
+            { ...id(String), name: 'first' },
+            { ...field(Number), name: 'second', options: { isId: true } }
+        ])
+    })
+})


### PR DESCRIPTION
A clever and helpful way to expose the fields and ids of an entity

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

Resolves the issue #60 

## Proposed Changes

1. Created 2 static getters on base entity: `fields` and `ids`
2. `fields` exposes the metadata of the entity fields
3. `ids` exposes the metadata of the entity ids (fields created with `id` ou with `idId = true` option)

## Readiness Checklist

### Author/Contributor
- [x] If documentation is needed for this change, has that been included in this pull request
- [x] Remember to check if code coverage decrease, if so, please implement the necessary tests

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
